### PR TITLE
travis: Disable sudo to use new, container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: perl
 perl:
     - "5.19"


### PR DESCRIPTION
By default, travis builds still use their legacy infrastructure instead
of the Docker-based infrastructure. Disabling sudo access is the magic
flag to use the Docker infrastructure
